### PR TITLE
Reset I at start of flight tailtune

### DIFF
--- a/src/main/flight/mixer_tricopter.c
+++ b/src/main/flight/mixer_tricopter.c
@@ -183,8 +183,6 @@ static int16_t tailMotorDecelerationDelay_angle;
 static servoParam_t * gpTailServoConf;
 static int16_t *gpTailServo;
 static mixerConfig_t *gpMixerConfig;
-static uint8_t currentIYaw;
-static float currentIYawf;
 
 static uint16_t tailServoADC = 0;
 static AdcChannel tailServoADCChannel = ADC_EXTERNAL1;
@@ -497,6 +495,9 @@ static void triTailTuneStep(servoParam_t *pServoConf, int16_t *pServoVal)
 
 static void tailTuneModeThrustTorque(struct thrustTorque_t *pTT, const bool isThrottleHigh)
 {
+    static uint8_t currentIYaw;
+    static float currentIYawf;
+
     switch(pTT->state)
     {
     case TT_IDLE:
@@ -516,7 +517,7 @@ static void tailTuneModeThrustTorque(struct thrustTorque_t *pTT, const bool isTh
             currentIYawf = currentProfile->pidProfile.I_f[FD_YAW];
             currentProfile->pidProfile.I8[FD_YAW] = 0;
             currentProfile->pidProfile.I_f[FD_YAW] = 0.0f;
-            pidResetErrorGyroYaw();
+            pidResetErrorGyroAxis(FD_YAW);
         }
         break;
     case TT_WAIT:

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -98,6 +98,12 @@ void pidResetErrorGyro(void)
     }
 }
 
+void pidResetErrorGyroYaw(void)
+{
+    errorGyroI[FD_YAW] = 0;
+    errorGyroIf[FD_YAW] = 0.0f;
+}
+
 float scaleItermToRcInput(int axis) {
     float rcCommandDeflection = (float)rcCommand[axis] / 500.0f;
     static float iTermScaler[3] = {1.0f, 1.0f, 1.0f};

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -98,10 +98,10 @@ void pidResetErrorGyro(void)
     }
 }
 
-void pidResetErrorGyroYaw(void)
+void pidResetErrorGyroAxis(const flight_dynamics_index_t axis)
 {
-    errorGyroI[FD_YAW] = 0;
-    errorGyroIf[FD_YAW] = 0.0f;
+    errorGyroI[axis] = 0;
+    errorGyroIf[axis] = 0.0f;
 }
 
 float scaleItermToRcInput(int axis) {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -86,4 +86,4 @@ extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 void pidSetController(pidControllerType_e type);
 void pidResetErrorAngle(void);
 void pidResetErrorGyro(void);
-
+void pidResetErrorGyroYaw(void);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -86,4 +86,4 @@ extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 void pidSetController(pidControllerType_e type);
 void pidResetErrorAngle(void);
 void pidResetErrorGyro(void);
-void pidResetErrorGyroYaw(void);
+void pidResetErrorGyroAxis(const flight_dynamics_index_t axis);


### PR DESCRIPTION
So be in steady hover before turning on tailtune to use this feature.
If the copter makes a yaw twist the bench tuning of servo middle was bad.
If the servo middle was good you shouldn't notice anything.

I think the flight tailtune quality depends on the bench tuning and wanted a way to verify.
Before I had tailtune results around 55. Tested with this feature and saw a small twist. After repeating the bench tuning until I couldn't see any twist I got a tailtune result 139, but I only tested once so far. Maybe just a lucky coincident, maybe not.
Please try this.
