### PR TITLE
Fix some more unit tests

### DIFF
--- a/src/test/unit/config_unittest.cc
+++ b/src/test/unit/config_unittest.cc
@@ -126,10 +126,6 @@ TEST(ConfigUnittest, TestResetConfigZeroValues)
 // resetControlRateConfig(&masterConfig.controlRateProfiles[0]);
     EXPECT_EQ(0, masterConfig.controlRateProfiles[0].thrExpo8);
     EXPECT_EQ(0, masterConfig.controlRateProfiles[0].dynThrPID);
-    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].rcYawExpo8);
-    for (uint8_t axis = 0; axis < FLIGHT_DYNAMICS_INDEX_COUNT; axis++) {
-        EXPECT_EQ(0, masterConfig.controlRateProfiles[0].rates[axis]);
-    }
 
     EXPECT_EQ(0, masterConfig.failsafeConfig.failsafe_kill_switch); // default failsafe switch action is identical to rc link loss
     EXPECT_EQ(0, masterConfig.failsafeConfig.failsafe_procedure);   // default full failsafe procedure is 0: auto-landing

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -235,8 +235,10 @@ protected:
             .thrExpo8 = 0,
             .rates = {0, 0, 0},
             .dynThrPID = 0,
+            .tpa_yaw_rate = 0,
             .rcYawExpo8 = 0,
-            .tpa_breakpoint = 0
+            .tpa_breakpoint = 0,
+            .tpa_yaw_breakpoint = 0
     };
 
     adjustmentRange_t adjustmentRange = {
@@ -300,19 +302,6 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsSticksInMiddle)
 
 TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp)
 {
-    // given
-    controlRateConfig_t controlRateConfig = {
-            .rcRate8 = 90,
-            .rcExpo8 = 0,
-            .thrMid8 = 0,
-            .thrExpo8 = 0,
-            .rates = {0,0,0},
-            .dynThrPID = 0,
-            .rcYawExpo8 = 0,
-            .tpa_breakpoint = 0
-    };
-
-    // and
     memset(&rxConfig, 0, sizeof (rxConfig));
     rxConfig.mincheck = DEFAULT_MIN_CHECK;
     rxConfig.maxcheck = DEFAULT_MAX_CHECK;


### PR DESCRIPTION
this PR fixes a few more issues in unit tests introduced in triflight. There are a few more to go until we get completely green. But I would prefer to push as much possible to avoid merge conflicts in my local copies :). 

Unit tests still failing:

> [  FAILED  ] PIDUnittest.TestPidLuxFloat
> [  FAILED  ] PIDUnittest.TestPidLuxFloatIntegrationForLinearFunction
> [  FAILED  ] PIDUnittest.TestPidLuxFloatIntegrationForQuadraticFunction
> [  FAILED  ] PIDUnittest.TestPidLuxFloatITermConstrain
> [  FAILED  ] PIDUnittest.TestPidMultiWiiRewriteITermConstrain
