### PR TITLE
Debug EXT1 ADC input function.

### DIFF
--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -20,10 +20,12 @@
 #include "io_types.h"
 
 typedef enum {
-    ADC_BATTERY = 0,
-    ADC_CURRENT = 1,
-    ADC_EXTERNAL1 = 2,
-    ADC_RSSI = 3,
+    ADC_BATTERY   = 0,
+    ADC_CURRENT   = 1,
+    ADC_RSSI      = 2,
+#ifdef EXTERNAL1_ADC_PIN
+    ADC_EXTERNAL1 = 3,
+#endif
     ADC_CHANNEL_COUNT
 } AdcChannel;
 

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -92,9 +92,11 @@ void adcInit(adcConfig_t *config)
         adcOperatingConfig[ADC_RSSI].tag = config->rssi.ioTag;  //RSSI_ADC_CHANNEL;
     }
 
+#ifdef EXTERNAL1_ADC_PIN
     if (config->external1.enabled) {
         adcOperatingConfig[ADC_EXTERNAL1].tag = config->external1.ioTag; //EXTERNAL1_ADC_CHANNEL;
     }
+#endif
 
     if (config->currentMeter.enabled) {
         adcOperatingConfig[ADC_CURRENT].tag = config->currentMeter.ioTag;  //CURRENT_METER_ADC_CHANNEL;

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -121,9 +121,11 @@ void adcInit(adcConfig_t *config)
         adcOperatingConfig[ADC_RSSI].tag = config->rssi.ioTag;  //RSSI_ADC_CHANNEL;
     }
 
+#ifdef EXTERNAL1_ADC_PIN
     if (config->external1.enabled) {
         adcOperatingConfig[ADC_EXTERNAL1].tag = config->external1.ioTag; //EXTERNAL1_ADC_CHANNEL;
     }
+#endif
 
     if (config->currentMeter.enabled) {
         adcOperatingConfig[ADC_CURRENT].tag = config->currentMeter.ioTag;  //CURRENT_METER_ADC_CHANNEL;

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -105,9 +105,11 @@ void adcInit(adcConfig_t *config)
         adcOperatingConfig[ADC_RSSI].tag = config->rssi.ioTag;  //RSSI_ADC_CHANNEL;
     }
 
+#ifdef EXTERNAL1_ADC_PIN
     if (config->external1.enabled) {
         adcOperatingConfig[ADC_EXTERNAL1].tag = config->external1.ioTag; //EXTERNAL1_ADC_CHANNEL;
     }
+#endif
 
     if (config->currentMeter.enabled) {
         adcOperatingConfig[ADC_CURRENT].tag = config->currentMeter.ioTag;  //CURRENT_METER_ADC_CHANNEL;

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -98,9 +98,11 @@ void adcInit(adcConfig_t *config)
         adcOperatingConfig[ADC_RSSI].tag = config->rssi.ioTag;  //RSSI_ADC_CHANNEL;
     }
 
+#ifdef EXTERNAL1_ADC_PIN
     if (config->external1.enabled) {
         adcOperatingConfig[ADC_EXTERNAL1].tag = config->external1.ioTag; //EXTERNAL1_ADC_CHANNEL;
     }
+#endif
 
     if (config->currentMeter.enabled) {
         adcOperatingConfig[ADC_CURRENT].tag = config->currentMeter.ioTag;  //CURRENT_METER_ADC_CHANNEL;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -375,9 +375,11 @@ void init(void)
             !feature(FEATURE_CURRENT_METER)) {
             adcConfig()->currentMeter.enabled = true;
         }
+#ifdef EXTERNAL1_ADC_PIN
         if (triMixerConfig()->tri_servo_feedback == TRI_SERVO_FB_EXT1) {
             adcConfig()->external1.enabled = true;
         }
+#endif
     }
     adcInit(adcConfig());
 #endif

--- a/src/main/flight/mixer_tricopter.c
+++ b/src/main/flight/mixer_tricopter.c
@@ -703,9 +703,9 @@ static AdcChannel getServoFeedbackADCChannel(uint8_t tri_servo_feedback)
     case TRI_SERVO_FB_CURRENT:
         channel = ADC_CURRENT;
         break;
-#ifdef ADC_EXTERNAL
+#ifdef EXTERNAL1_ADC_PIN
     case TRI_SERVO_FB_EXT1:
-        channel = ADC_EXTERNAL;
+        channel = ADC_EXTERNAL1;
         break;
 #endif
     default:


### PR DESCRIPTION
Could not get servo fdbk to function properly on RCE NAZE32 board, as evidenced by disarmed tailtune failure.  After analyzing the code, I made the changes in this PR.  I was then able to verify RCE NAZE32 servo fdbk functionality.  It should be noted that while I can't test any other target hardware, all targets successfully compiled.