### PR TITLE
Set feedback option EXT1 to PWM1 (PA6) on BFF3

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.h
+++ b/src/main/target/BETAFLIGHTF3/target.h
@@ -119,6 +119,7 @@
 #define VBAT_ADC_PIN            PA4
 #define CURRENT_METER_ADC_PIN   PA5
 #define RSSI_ADC_PIN            PB2
+#define EXTERNAL1_ADC_PIN       PA6
 
 #define LED_STRIP
 


### PR DESCRIPTION
Need a doc update as well I think.